### PR TITLE
add rerender function to _removeFile

### DIFF
--- a/src/js/Attachment/index.ts
+++ b/src/js/Attachment/index.ts
@@ -158,6 +158,8 @@ class Attachment extends Control<AttachmentProps> {
 
   private _removeFile(index: number) {
     this._props.files && this._props.files.splice(index, 1);
+    this.listFileEl.innerHTML = '';
+    this.rerender(['files']);
     this._onFileRemove(this._props.files);
   }
 


### PR DESCRIPTION
社内で不具合登録した件です。
日本語ですが再掲です。

## Version

- @kintone/kintone-ui-component v0.7.7

## Environment

- Browser:Chrome 89.0.4389.90（Official Build） （x86_64）

## Current Behavior

1. UI Componentの添付ファイルフィールドを配置する
2. 配置したフィールドへ添付ファイルを複数添付すす
3. 配置された添付ファイルを上から順に✗ボタンですべて削除する
4. 現象発生：画面上はすべて削除されるが、内部的にはいくつかのFileを保持している

## Expected Behavior

[4.]で内部的にも全てのファイルが削除されている

## 原因

[ファイルの削除時の処理](https://github.com/kintone-labs/kintone-ui-component/blob/b759ea14109179e78d750e52b0f97edd58f4edd8/src/js/Attachment/index.ts#L159-L162)で保持しているファイルの配列の該当ファイルを削除し、配列内のindexが変更されるが、[内部で割り当てられているindex](https://github.com/kintone-labs/kintone-ui-component/blob/b759ea14109179e78d750e52b0f97edd58f4edd8/src/js/Attachment/index.ts#L64-L70)が変更されないため、indexの不整合が発生し、後続の削除処理では意図しないファイル(✗ボタンを押したファイルではないファイル)のindexや存在しないindexを指定して削除処理を実行している模様。