### PR TITLE
SSR-6049: Fix mobile notification stacking below kintone header

### DIFF
--- a/src/mobile/notification/style.ts
+++ b/src/mobile/notification/style.ts
@@ -10,6 +10,7 @@ export const MOBILE_NOTIFICATION_CSS = `
     position: relative;
     top: -100px;
     left: 0;
+    z-index: 10000;
   }
   kuc-mobile-notification:lang(es),
   kuc-mobile-notification:lang(es) * {
@@ -49,7 +50,7 @@ export const MOBILE_NOTIFICATION_CSS = `
     background: linear-gradient(#ffda4a, #ffc32c);
     width: 100%;
     min-height: 48px;
-    z-index: 20;
+    position: relative;
     font-size: 12px;
     font-weight: 700;
     line-height: 14px;


### PR DESCRIPTION
## Summary
- Mobile notification toast was painted behind kintone's mobile header.
- Add a high `z-index` on the `kuc-mobile-notification` host and switch the inner message div to `position: relative` so it stacks above the header.